### PR TITLE
[CLI][API]Getting rid of deprecated api call

### DIFF
--- a/wanchain_web3/utils/underscore.js
+++ b/wanchain_web3/utils/underscore.js
@@ -1,5 +1,5 @@
 const _ = module.exports = require('underscore');
-const uuid = require('uuid');
+const uuidv4 = require('uuid/v4');
 const underscoreDeepExtend = require('underscore-deep-extend');
 
 _.mixin({
@@ -32,7 +32,7 @@ _.mixin({
     },
     deepExtend: underscoreDeepExtend(_),
     uuid() {
-        return uuid.v4();
+        return uuidv4();
     },
 });
 


### PR DESCRIPTION
- As per [uuid](https://github.com/kelektiv/node-uuid#deprecated-api) package doc, accessing individual version as function call is deprecated and won't supported post our current package version. 
- Fix to take care of future breaking change

@cranelv  - please help to review, thanks!
